### PR TITLE
Add and preprocess TSB-UAD datasets

### DIFF
--- a/docs/user/usage-timeeval.md
+++ b/docs/user/usage-timeeval.md
@@ -13,7 +13,7 @@ If you want to use your own datasets with TimeEval, please read [](integrate-dat
 For the evaluation of time series anomaly detection algorithms, we collected univariate and multivariate time series datasets from various sources.
 We looked out for real-world as well as synthetically generated datasets with real-valued values and anomaly annotations.
 We included datasets with direct anomaly annotations (points or subsequences are labelled as either normal (0) or anomalous (1)) and indirect anomaly annotations.
-For the later, we included datasets with categorical labels, where a single class (or low number of classes) is clearly underrepresented and can be assigned to unwanted, erroneous, or anomalous behavior.
+For the latter, we included datasets with categorical labels, where a single class (or low number of classes) is clearly underrepresented and can be assigned to unwanted, erroneous, or anomalous behavior.
 One example for this is an ECG signal with beat annotations, where most beats are annotated as normal beats, but some beats are premature or superventricular heart beats.
 The premature or superventricular heart beats can then be labelled as anomalous while the rest of the time series is normal behavior.
 Overall, we collected 1354 datasets (as of May 2022).
@@ -37,7 +37,7 @@ It is compatible to TimeEval and generates TimeEval-compatible datasets and also
 The downloadable ZIP-archives contain the correct folder structure, but your extraction tool might place the contained files into a new folder that is named based on the ZIP-archive-name.
 The idea is that you download the index-File (`datasets.csv`) and just the dataset collections that you require, extract them all into the same folder, and then place the `datasets.csv` there.
 Please note or remember the name of your datasets folder.
-We will need it later and we will refer to it as `<datasets-folder>`
+We will need it later, and we will refer to it as `<datasets-folder>`
 
 **Example:**
 
@@ -85,9 +85,9 @@ datasets.append(dm.select(collection="Daphnet"))
 ### Dataset download links
 
 Please consider the repeatability page for a complete list of up-to-date download links.
-This section is just for your convenience and we don't update it very frequently!
+This section is just for your convenience, and we don't update it very frequently!
 
-- [index-File ⬇](https://owncloud.hpi.de/s/3Cp8Q5H9gn7EVK0/download) (`datasets.csv`, <1MB)
+- [index-File ⬇](https://owncloud.hpi.de/s/fMIXN7bIvuBMDv1/download) (`datasets.csv`, <1MB)
 - [CalIt2 ⬇](https://owncloud.hpi.de/s/JhYwxfWp5JX05uA/download) (<1MB)
 - [Daphnet ⬇](https://owncloud.hpi.de/s/ieohjdwJrg9WWAp/download) (15MB)
 - [Dodgers ⬇](https://owncloud.hpi.de/s/h5BTYIGX3FDb3RQ/download) (<1MB))
@@ -108,6 +108,8 @@ This section is just for your convenience and we don't update it very frequently
 - [Occupancy ⬇](https://owncloud.hpi.de/s/wrIxS1BiaX8AGyC/download) (<1MB)
 - [SMD ⬇](https://owncloud.hpi.de/s/Ea7rsjmDErZ3QCN/download) (99MB)
 - [SVDB ⬇](https://owncloud.hpi.de/s/qsyGjJb9UtDFfCa/download) (103MB)
+- [TSB-UAD synthetic ⬇](https://owncloud.hpi.de/s/bHFHI7eEKC6GVxN/download) (1.8GB)
+- [TSB-UAD artificial ⬇](https://owncloud.hpi.de/s/CxBDzfuXzfHQeWv/download) (178MB)
 - [GutenTAG ⬇](https://owncloud.hpi.de/s/pmI2A3Msa46cYnK/download) (own `datasets.csv`-File, 106MB)
 
 ## Prepare algorithms
@@ -117,7 +119,7 @@ If you want to integrate your own algorithm into TimeEval, please read [](integr
 
 We collected over 70 time series anomaly detection algorithms and integrated them into TimeEval (as of May 2022).
 All of our algorithm implementation make use of the {class}`~timeeval.adapters.docker.DockerAdapter` to allow you to use all features of TimeEval with them (such as resource restrictions, timeout, and fair runtime measurements).
-You can find the TimeEval algorithm implementations on Github: <https://github.com/HPI-Information-Systems/TimeEval-algorithms>.
+You can find the TimeEval algorithm implementations on GitHub: <https://github.com/HPI-Information-Systems/TimeEval-algorithms>.
 Using Docker images to bundle an algorithm for TimeEval also allows easy integration of new algorithms because there are no requirements regarding programming languages, frameworks, or tools.
 Besides the many benefits, using Docker images to bundle algorithms makes preparing them for use with TimeEval a bit more cumbursome.
 
@@ -155,7 +157,7 @@ pip install TimeEval
 ```
 
 We recommend to create a virtual environment with conda or virtualenv for TimeEval.
-The software requirements of TimeEval can found on [the home page](../index).
+The software requirements of TimeEval can be found on [the home page](../index).
 
 When TimeEval ist installed, we can use its Python API to configure an evaluation run.
 We recommend to create a single Python-script for each evaluation run.
@@ -178,14 +180,14 @@ def main():
     ####################
     dm = MultiDatasetManager([
         Path("<datasets-folder>")  # e.g. ./timeeval-datasets
-        # you can multiple folder with an index-File to the MultiDatasetManager
+        # you can add multiple folders with an index-File to the MultiDatasetManager
     ])
     # A DatasetManager reads the index-File and allows you to access dataset metadata,
     # the datasets itself, or provides utilities to filter datasets by their metadata.
     # - select ALL available datasets
     # datasets = dm.select()
     # - select datasets from Daphnet collection
-    dataset = dm.select(collection="Daphnet")
+    datasets = dm.select(collection="Daphnet")
     # - select datasets with at least 2 anomalies
     # datasets = dm.select(min_anomalies=2)
     # - select multivariate datasets with a maximum contamination of 10%
@@ -238,7 +240,7 @@ def main():
     timeeval = TimeEval(dm, datasets, algorithms,
         repetitions=repetitions,
         resource_constraints=rcs,
-        # you can chose from different metrics:
+        # you can choose from different metrics:
         metrics=[DefaultMetrics.ROC_AUC, DefaultMetrics.FIXED_RANGE_PR_AUC],
     )
 

--- a/notebooks/data-prep/Overview.md
+++ b/notebooks/data-prep/Overview.md
@@ -1,40 +1,40 @@
 # Overview about the dataset preprocessing process
 
 | Dataset Collection (folder names)      |Status | Notebook       | Comments                                                                                     |
-| :------------------------------------- |:----:|:---------------|:---------------------------------------------------------------------------------------------|
-| ATLAS Higgs Boson Challenge            |  x   | [🗎][ATLAS]    | Classification dataset; time component arbitrary                                             |
-| Community-NAB                          |  ✓   | [🗎][NAB]      |                                                                                              |
-| IOPS AI Challenge                      |  ✓   | [🗎][IOPS]     |                                                                                              |
-| KDD Robot Execution Failures           |  x   |                | Only very short sequences and annotations are per sequence instead of per point!             |
-| MIT-BIH Arrhythmia DB                  |  ✓   | [🗎][mitdb]    | Complex generation of anomaly-windows to label datasets.                                     |
-| MIT-BIH Long-Term ECG Database         |  ✓   | [🗎][ltdb]     | See _MIT-BIH Arrhythmia DB_ for preprocessing explanation.                                   |
-| MIT-BIH Supraventricular Arrhythmia DB |  ✓   | [🗎][svdb]     | See _MIT-BIH Arrhythmia DB_ for preprocessing explanation.                                   |
-| NASA Spacecraft Telemetry Data         |  ✓   | [🗎][NASA]     | SMAP and MSL datasets                                                                        |
-| Series2Graph                           | tbd  |                | **No labels ATM!**                                                                           |
-| Server Machine Dataset                 |  ✓   | [🗎][SMD]      |                                                                                              |
-| TSBitmap                               |  x   |                | **No labels!**                                                                               |
-| UCI ML Repository / 3W                 |  x   | [🗎][3W]       | Hard to transform into TS AD task.                                                           |
-| UCI ML Repository / CalIt2             |  ✓   | [🗎][CalIt2]   |                                                                                              |
-| UCI ML Repository / Condition monitoring|  x   | [🗎][Cond]     | Whole-sequence annotations; multiple condition annotations per sequence!                    |
-| UCI ML Repository / Daphnet            |  ✓   | [🗎][Daph]     |                                                                                              |
-| UCI ML Repository / Dodgers            |  ✓   | [🗎][Dodgers]  | Missing values are marked as anomalies as well.                                              |
-| UCI ML Repository / HEPMASS            |  x   |                | Classification dataset; time component arbitrary                                             |
-| UCI ML Repository / Kitsune Network Attack|  ✓   | [🗎][Kitsune] | Very large datasets; distance between points (network packets) unclear                     |
-| UCI ML Repository / Metro              |  ✓   | [🗎][Metro]    |                                                                                              |
-| UCI ML Repository / OPPORTUNITY        |  ✓   | [🗎][OPP]      | To-Lie is regarded as anomaly. A lot of missing values!                                      |
-| UCI ML Repository / Occupancy Detection|  ✓   | [🗎][Occu]     |                                                                                              |
-| UCI ML Repository / URLReputation      |  x   |                | No real time series; labels are per item, but no way to follow an item over the time period. |
-| Webscope-S5                            |  ✓   | [🗎][Yahoo]    |                                                                                              |
-| credit-card-fraud                      |  x   |                | Timestamps are not equi-distant.                                                             |
-| genesis-demonstrator                   |  ✓   | [🗎][gen]      | A single dataset                                                                             |
-| GHL                                    |  ✓   | [🗎][ghl]      |                                                                                              |
-| SSA                                    |  ✓   | [🗎][ssa]      | Annotation source unclear, brittle datasets.                                                 |
-| Keogh                                  |  ✓   | [🗎][keogh]    | Collection of datasets from Eammon Keogh                                                     |
-| MGAB                                   |  ✓   | [🗎][mgab]     |                                                                                              |
-| KDD-TSAD-contest                       |  ✓   | [🗎][kdd-tsad] |                                                                                              |
-| SWaT                                   |   ✓  | [🗎][swat]     |                                                                                              |
-| WADI                                   |   ✓  | [🗎][wadi]     |                                                                                              |
-| TSB-UAD                                |      | [🗎][TSB-UDA]  | benchmark datasets are already included in our other collections                             |
+| :------------------------------------- |:-----:|:---------------|:---------------------------------------------------------------------------------------------|
+| ATLAS Higgs Boson Challenge            |   x   | [🗎][ATLAS]    | Classification dataset; time component arbitrary                                             |
+| Community-NAB                          |   ✓   | [🗎][NAB]      |                                                                                              |
+| IOPS AI Challenge                      |   ✓   | [🗎][IOPS]     |                                                                                              |
+| KDD Robot Execution Failures           |   x   |                | Only very short sequences and annotations are per sequence instead of per point!             |
+| MIT-BIH Arrhythmia DB                  |   ✓   | [🗎][mitdb]    | Complex generation of anomaly-windows to label datasets.                                     |
+| MIT-BIH Long-Term ECG Database         |   ✓   | [🗎][ltdb]     | See _MIT-BIH Arrhythmia DB_ for preprocessing explanation.                                   |
+| MIT-BIH Supraventricular Arrhythmia DB |   ✓   | [🗎][svdb]     | See _MIT-BIH Arrhythmia DB_ for preprocessing explanation.                                   |
+| NASA Spacecraft Telemetry Data         |   ✓   | [🗎][NASA]     | SMAP and MSL datasets                                                                        |
+| Series2Graph                           |  tbd  |                | **No labels ATM!**                                                                           |
+| Server Machine Dataset                 |   ✓   | [🗎][SMD]      |                                                                                              |
+| TSBitmap                               |   x   |                | **No labels!**                                                                               |
+| UCI ML Repository / 3W                 |   x   | [🗎][3W]       | Hard to transform into TS AD task.                                                           |
+| UCI ML Repository / CalIt2             |   ✓   | [🗎][CalIt2]   |                                                                                              |
+| UCI ML Repository / Condition monitoring|   x   | [🗎][Cond]     | Whole-sequence annotations; multiple condition annotations per sequence!                    |
+| UCI ML Repository / Daphnet            |   ✓   | [🗎][Daph]     |                                                                                              |
+| UCI ML Repository / Dodgers            |   ✓   | [🗎][Dodgers]  | Missing values are marked as anomalies as well.                                              |
+| UCI ML Repository / HEPMASS            |   x   |                | Classification dataset; time component arbitrary                                             |
+| UCI ML Repository / Kitsune Network Attack|   ✓   | [🗎][Kitsune] | Very large datasets; distance between points (network packets) unclear                     |
+| UCI ML Repository / Metro              |   ✓   | [🗎][Metro]    |                                                                                              |
+| UCI ML Repository / OPPORTUNITY        |   ✓   | [🗎][OPP]      | To-Lie is regarded as anomaly. A lot of missing values!                                      |
+| UCI ML Repository / Occupancy Detection|   ✓   | [🗎][Occu]     |                                                                                              |
+| UCI ML Repository / URLReputation      |   x   |                | No real time series; labels are per item, but no way to follow an item over the time period. |
+| Webscope-S5                            |   ✓   | [🗎][Yahoo]    |                                                                                              |
+| credit-card-fraud                      |   x   |                | Timestamps are not equi-distant.                                                             |
+| genesis-demonstrator                   |   ✓   | [🗎][gen]      | A single dataset                                                                             |
+| GHL                                    |   ✓   | [🗎][ghl]      |                                                                                              |
+| SSA                                    |   ✓   | [🗎][ssa]      | Annotation source unclear, brittle datasets.                                                 |
+| Keogh                                  |   ✓   | [🗎][keogh]    | Collection of datasets from Eammon Keogh                                                     |
+| MGAB                                   |   ✓   | [🗎][mgab]     |                                                                                              |
+| KDD-TSAD-contest                       |   ✓   | [🗎][kdd-tsad] |                                                                                              |
+| SWaT                                   |   ✓   | [🗎][swat]     |                                                                                              |
+| WADI                                   |   ✓   | [🗎][wadi]     |                                                                                              |
+| TSB-UAD                                |   ✓   | [🗎][TSB-UDA]  | benchmark datasets are already included in our other collections                             |
 
 ## TODO
 

--- a/notebooks/data-prep/Overview.md
+++ b/notebooks/data-prep/Overview.md
@@ -1,39 +1,40 @@
 # Overview about the dataset preprocessing process
 
-| Dataset Collection (folder names)      | Status| Notebook   | Comments |
-| :------------------------------------- | :---: | :--------- | :------- |
-| ATLAS Higgs Boson Challenge            |   x   | [🗎][ATLAS] | Classification dataset; time component arbitrary |
-| Community-NAB                          |   ✓   | [🗎][NAB]   |  |
-| IOPS AI Challenge                      |   ✓   | [🗎][IOPS]  |  |
-| KDD Robot Execution Failures           |   x   |            | Only very short sequences and annotations are per sequence instead of per point! |
-| MIT-BIH Arrhythmia DB                  |   ✓   | [🗎][mitdb] | Complex generation of anomaly-windows to label datasets. |
-| MIT-BIH Long-Term ECG Database         |   ✓   | [🗎][ltdb]  | See _MIT-BIH Arrhythmia DB_ for preprocessing explanation. |
-| MIT-BIH Supraventricular Arrhythmia DB |   ✓   | [🗎][svdb]  | See _MIT-BIH Arrhythmia DB_ for preprocessing explanation. |
-| NASA Spacecraft Telemetry Data         |   ✓   | [🗎][NASA]  | SMAP and MSL datasets |
-| Series2Graph                           |  tbd  |            | **No labels ATM!** |
-| Server Machine Dataset                 |   ✓   | [🗎][SMD]   |  |
-| TSBitmap                               |   x   |            | **No labels!** |
-| UCI ML Repository / 3W                 |   x   | [🗎][3W]    | Hard to transform into TS AD task. |
-| UCI ML Repository / CalIt2             |   ✓   | [🗎][CalIt2]|  |
-| UCI ML Repository / Condition monitoring|  x   | [🗎][Cond]  | Whole-sequence annotations; multiple condition annotations per sequence! |
-| UCI ML Repository / Daphnet            |   ✓   | [🗎][Daph]  |  |
-| UCI ML Repository / Dodgers            |   ✓   |[🗎][Dodgers]| Missing values are marked as anomalies as well. |
-| UCI ML Repository / HEPMASS            |   x   |            | Classification dataset; time component arbitrary |
-| UCI ML Repository / Kitsune Network Attack|✓   |[🗎][Kitsune]| Very large datasets; distance between points (network packets) unclear |
-| UCI ML Repository / Metro              |   ✓   | [🗎][Metro] |  |
-| UCI ML Repository / OPPORTUNITY        |   ✓   | [🗎][OPP]   | To-Lie is regarded as anomaly. A lot of missing values! |
-| UCI ML Repository / Occupancy Detection|   ✓   | [🗎][Occu]  |  |
-| UCI ML Repository / URLReputation      |   x   |            | No real time series; labels are per item, but no way to follow an item over the time period. |
-| Webscope-S5                            |   ✓   | [🗎][Yahoo] |  |
-| credit-card-fraud                      |   x   |            | Timestamps are not equi-distant. |
-| genesis-demonstrator                   |   ✓   | [🗎][gen]   | A single dataset |
-| GHL                                    |   ✓   | [🗎][ghl]   | |
-| SSA                                    |   ✓   | [🗎][ssa]   | Annotation source unclear, brittle datasets. |
-| Keogh                                  |   ✓   | [🗎][keogh] | Collection of datasets from Eammon Keogh |
-| MGAB                                   |   ✓   | [🗎][mgab]  |  |
-| KDD-TSAD-contest                       |   ✓   | [🗎][kdd-tsad]|  |
-| SWaT                                   |       | [🗎][swat]  |  |
-| WADI                                   |       | [🗎][wadi]  |  |
+| Dataset Collection (folder names)      |Status | Notebook       | Comments                                                                                     |
+| :------------------------------------- |:----:|:---------------|:---------------------------------------------------------------------------------------------|
+| ATLAS Higgs Boson Challenge            |  x   | [🗎][ATLAS]    | Classification dataset; time component arbitrary                                             |
+| Community-NAB                          |  ✓   | [🗎][NAB]      |                                                                                              |
+| IOPS AI Challenge                      |  ✓   | [🗎][IOPS]     |                                                                                              |
+| KDD Robot Execution Failures           |  x   |                | Only very short sequences and annotations are per sequence instead of per point!             |
+| MIT-BIH Arrhythmia DB                  |  ✓   | [🗎][mitdb]    | Complex generation of anomaly-windows to label datasets.                                     |
+| MIT-BIH Long-Term ECG Database         |  ✓   | [🗎][ltdb]     | See _MIT-BIH Arrhythmia DB_ for preprocessing explanation.                                   |
+| MIT-BIH Supraventricular Arrhythmia DB |  ✓   | [🗎][svdb]     | See _MIT-BIH Arrhythmia DB_ for preprocessing explanation.                                   |
+| NASA Spacecraft Telemetry Data         |  ✓   | [🗎][NASA]     | SMAP and MSL datasets                                                                        |
+| Series2Graph                           | tbd  |                | **No labels ATM!**                                                                           |
+| Server Machine Dataset                 |  ✓   | [🗎][SMD]      |                                                                                              |
+| TSBitmap                               |  x   |                | **No labels!**                                                                               |
+| UCI ML Repository / 3W                 |  x   | [🗎][3W]       | Hard to transform into TS AD task.                                                           |
+| UCI ML Repository / CalIt2             |  ✓   | [🗎][CalIt2]   |                                                                                              |
+| UCI ML Repository / Condition monitoring|  x   | [🗎][Cond]     | Whole-sequence annotations; multiple condition annotations per sequence!                    |
+| UCI ML Repository / Daphnet            |  ✓   | [🗎][Daph]     |                                                                                              |
+| UCI ML Repository / Dodgers            |  ✓   | [🗎][Dodgers]  | Missing values are marked as anomalies as well.                                              |
+| UCI ML Repository / HEPMASS            |  x   |                | Classification dataset; time component arbitrary                                             |
+| UCI ML Repository / Kitsune Network Attack|  ✓   | [🗎][Kitsune] | Very large datasets; distance between points (network packets) unclear                     |
+| UCI ML Repository / Metro              |  ✓   | [🗎][Metro]    |                                                                                              |
+| UCI ML Repository / OPPORTUNITY        |  ✓   | [🗎][OPP]      | To-Lie is regarded as anomaly. A lot of missing values!                                      |
+| UCI ML Repository / Occupancy Detection|  ✓   | [🗎][Occu]     |                                                                                              |
+| UCI ML Repository / URLReputation      |  x   |                | No real time series; labels are per item, but no way to follow an item over the time period. |
+| Webscope-S5                            |  ✓   | [🗎][Yahoo]    |                                                                                              |
+| credit-card-fraud                      |  x   |                | Timestamps are not equi-distant.                                                             |
+| genesis-demonstrator                   |  ✓   | [🗎][gen]      | A single dataset                                                                             |
+| GHL                                    |  ✓   | [🗎][ghl]      |                                                                                              |
+| SSA                                    |  ✓   | [🗎][ssa]      | Annotation source unclear, brittle datasets.                                                 |
+| Keogh                                  |  ✓   | [🗎][keogh]    | Collection of datasets from Eammon Keogh                                                     |
+| MGAB                                   |  ✓   | [🗎][mgab]     |                                                                                              |
+| KDD-TSAD-contest                       |  ✓   | [🗎][kdd-tsad] |                                                                                              |
+| SWaT                                   |   ✓  | [🗎][swat]     |                                                                                              |
+| WADI                                   |   ✓  | [🗎][wadi]     |                                                                                              |
+| TSB-UAD                                |      | [🗎][TSB-UDA]  | benchmark datasets are already included in our other collections                             |
 
 ## TODO
 
@@ -73,3 +74,4 @@ Check against datasets in [John's benchmark framework](https://github.com/johnpa
 [kdd-tsad]: ./KDD-TSAD.ipynb
 [swat]: ./SWaT.ipynb
 [wadi]: ./WADI.ipynb
+[TSB-UDA]: ./TSB-UAD.ipynb

--- a/notebooks/data-prep/TSB-UAD.ipynb
+++ b/notebooks/data-prep/TSB-UAD.ipynb
@@ -1,0 +1,329 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# TSB-UAD: An End-to-End Benchmark Suite for Univariate Time-Series Anomaly Detection\n",
+    "\n",
+    "- Source and description: https://github.com/TheDatumOrg/TSB-UAD\n",
+    "- Paper: https://dl.acm.org/doi/pdf/10.14778/3529337.3529354"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from config import data_raw_folder, data_processed_folder\n",
+    "from timeeval import DatasetManager, Datasets\n",
+    "from timeeval.datasets import DatasetAnalyzer, DatasetRecord"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.rcParams[\"figure.figsize\"] = (20, 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def find_datasets(folder):\n",
+    "    if not isinstance(folder, Path):\n",
+    "        folder = Path(folder)\n",
+    "    return sorted([f for f in folder.glob(\"*.out\") if f.is_file()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dataset_collection_name = \"TSB-UAD\"\n",
+    "source_folder = Path(data_raw_folder) / \"TSB-UAD\"\n",
+    "target_folder = Path(data_processed_folder)\n",
+    "\n",
+    "print(f\"Looking for source datasets in {Path(source_folder).absolute()} and\\nsaving processed datasets in {Path(target_folder).absolute()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# shared by all datasets\n",
+    "dataset_type = \"synthetic\"\n",
+    "input_type = \"univariate\"\n",
+    "datetime_index = False\n",
+    "split_at = None\n",
+    "train_is_normal = False\n",
+    "train_type = \"unsupervised\"\n",
+    "\n",
+    "dm = DatasetManager(target_folder, create_if_missing=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def process_dataset(dm: DatasetManager, idx: int, f: Path, name_prefix: str = \"\") -> None:\n",
+    "    print(f\"> Processing source dataset {idx}\")\n",
+    "    dataset_name = f\"{name_prefix}-{f.stem}\"\n",
+    "    test_filename = f\"{dataset_name}.test.csv\"\n",
+    "    test_path = dataset_subfolder / test_filename\n",
+    "    target_test_filepath = target_subfolder / test_filename\n",
+    "    target_meta_filepath = target_test_filepath.parent / f\"{dataset_name}.{Datasets.METADATA_FILENAME_SUFFIX}\"\n",
+    "\n",
+    "    # Prepare datasets\n",
+    "    if not target_test_filepath.exists() or not target_meta_filepath.exists():\n",
+    "        df_test = pd.read_csv(f, header=None)\n",
+    "        df_test.columns = [\"value\", \"is_anomaly\"]\n",
+    "        df_test.insert(0, \"timestamp\", df_test.index)\n",
+    "        df_test.to_csv(target_test_filepath, index=False)\n",
+    "        print(f\"  written dataset {idx}\")\n",
+    "    else:\n",
+    "        df_test = None\n",
+    "        print(f\"  skipped writing dataset {idx} to disk, because it already exists.\")\n",
+    "\n",
+    "    # Prepare metadata\n",
+    "    def analyze(df_test):\n",
+    "        da = DatasetAnalyzer((dataset_collection_name, dataset_name), is_train=False, df=df_test, ignore_stationarity=True)\n",
+    "        da.save_to_json(target_meta_filepath, overwrite=True)\n",
+    "        meta = da.metadata\n",
+    "        print(f\"  analyzed test dataset {idx}\")\n",
+    "        return meta\n",
+    "\n",
+    "    if target_meta_filepath.exists():\n",
+    "        try:\n",
+    "            meta = DatasetAnalyzer.load_from_json(target_meta_filepath, train=False)\n",
+    "            print(f\"  skipped analyzing dataset {idx}, because metadata already exists.\")\n",
+    "        except ValueError:\n",
+    "            if df_test is None:\n",
+    "                df_test = pd.read_csv(target_test_filepath)\n",
+    "            meta = analyze(df_test)\n",
+    "    else:\n",
+    "        meta = analyze(df_test)\n",
+    "\n",
+    "    dm.add_dataset(DatasetRecord(\n",
+    "          collection_name=dataset_collection_name,\n",
+    "          dataset_name=dataset_name,\n",
+    "          train_path=None,\n",
+    "          test_path=test_path,\n",
+    "          dataset_type=dataset_type,\n",
+    "          datetime_index=datetime_index,\n",
+    "          split_at=split_at,\n",
+    "          train_type=train_type,\n",
+    "          train_is_normal=train_is_normal,\n",
+    "          input_type=input_type,\n",
+    "          length=meta.length,\n",
+    "          dimensions=meta.dimensions,\n",
+    "          contamination=meta.contamination,\n",
+    "          num_anomalies=meta.num_anomalies,\n",
+    "          min_anomaly_length=meta.anomaly_length.min,\n",
+    "          median_anomaly_length=meta.anomaly_length.median,\n",
+    "          max_anomaly_length=meta.anomaly_length.max,\n",
+    "          mean=meta.mean,\n",
+    "          stddev=meta.stddev,\n",
+    "          trend=meta.trend,\n",
+    "          stationarity=meta.get_stationarity_name(),\n",
+    "          period_size=np.nan\n",
+    "    ))\n",
+    "    print(f\"... processed source dataset {idx}: {name_prefix}-{f.name} -> {target_test_filepath}\")\n",
+    "\n",
+    "subcollection = \"artificial\"\n",
+    "\n",
+    "print(\"#############\")\n",
+    "print(f\"# Processing sub-collection {subcollection}\")\n",
+    "print(\"#############\")\n",
+    "\n",
+    "# create target directory\n",
+    "dataset_subfolder = Path(input_type) / f\"{dataset_collection_name}-{subcollection}\"\n",
+    "target_subfolder = target_folder / dataset_subfolder\n",
+    "target_subfolder.mkdir(parents=True, exist_ok=True)\n",
+    "print(f\"Created directories {target_subfolder}\")\n",
+    "\n",
+    "folder = source_folder / subcollection\n",
+    "\n",
+    "i = 0\n",
+    "for file in find_datasets(folder):\n",
+    "    process_dataset(dm, i, file)\n",
+    "    i += 1\n",
+    "dm.save()\n",
+    "\n",
+    "\n",
+    "subcollection = \"synthetic\"\n",
+    "\n",
+    "print(\"#############\")\n",
+    "print(f\"# Processing sub-collection {subcollection}\")\n",
+    "print(\"#############\")\n",
+    "\n",
+    "# create target directory\n",
+    "dataset_subfolder = Path(input_type) / f\"{dataset_collection_name}-{subcollection}\"\n",
+    "target_subfolder = target_folder / dataset_subfolder\n",
+    "target_subfolder.mkdir(parents=True, exist_ok=True)\n",
+    "print(f\"Created directories {target_subfolder}\")\n",
+    "\n",
+    "folder = source_folder / subcollection\n",
+    "\n",
+    "for subfolder in folder.iterdir():\n",
+    "    if subfolder.is_dir():\n",
+    "        for file in find_datasets(subfolder):\n",
+    "            process_dataset(dm, i, file, name_prefix=subfolder.stem)\n",
+    "            i += 1\n",
+    "dm.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dm.refresh()\n",
+    "dm.df().loc[(slice(dataset_collection_name,dataset_collection_name), slice(None))]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Exploration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "folder = source_folder / \"artificial\"\n",
+    "datasets = find_datasets(folder)\n",
+    "[d.name for d in datasets]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "f = datasets[10]\n",
+    "df = pd.read_csv(f, header=None)\n",
+    "df.columns = [\"value\", \"is_anomaly\"]\n",
+    "df.insert(0, \"timestamp\", df.index)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df.plot(subplots=True)\n",
+    "# plt.xlim(anomaly[0]-1500, anomaly[1]+1500)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
Add datasets from the TSB-UAD benchmark collection: https://github.com/TheDatumOrg/TSB-UAD.

Our preprocessed datasets can be downloaded from:

- [TSB-UAD synthetic ⬇](https://owncloud.hpi.de/s/bHFHI7eEKC6GVxN/download) (1.8GB)
- [TSB-UAD artificial ⬇](https://owncloud.hpi.de/s/CxBDzfuXzfHQeWv/download) (178MB)