### PR TITLE
Update usage of PyThresh library to new (fixed) version

### DIFF
--- a/requirements.ci
+++ b/requirements.ci
@@ -4,7 +4,7 @@ mypy==0.920
 twine
 freezegun
 # for the test of the PyThreshThresholding class:
-pythresh
+pythresh>=0.2.8
 
 # typings
 types-requests

--- a/tests/metrics/test_thresholding.py
+++ b/tests/metrics/test_thresholding.py
@@ -61,6 +61,27 @@ class TestThresholding(unittest.TestCase):
 
     @pytest.mark.skipif(_skip_pythresh_test == True, reason="PyThresh is not installed!")
     def test_pythresh_thresholding(self):
+        import pythresh.version
         from pythresh.thresholds.regr import REGR
-        strategy = PyThreshThresholding(pythresh_thresholder=REGR(method="theil"), random_state=42)
-        self._test_strategy(strategy, 0.44, [0, 0, 1, 1, 1, 1, 0, 0, 0])
+
+        with self.assertWarnsRegex(DeprecationWarning, "parameter is deprecated"):
+            strategy = PyThreshThresholding(pythresh_thresholder=REGR(method="theil"), random_state=42)
+
+        pythresh_version = list(map(int, pythresh.version.__version__.split(".")))
+        if pythresh_version >= [0, 2, 8]:
+            exp_threshold = 0.72
+            exp_res = [0, 0, 1, 0, 0, 0, 0, 0, 0]
+        else:
+            exp_threshold = 0.44
+            exp_res = [0, 0, 1, 1, 1, 1, 0, 0, 0]
+        self._test_strategy(strategy, exp_threshold, exp_res)
+
+    @pytest.mark.skipif(_skip_pythresh_test == True, reason="PyThresh is not installed!")
+    def test_pythresh_thresholding_new(self):
+        import pythresh.version
+        from pythresh.thresholds.regr import REGR
+
+        pythresh_version = list(map(int, pythresh.version.__version__.split(".")))
+        if pythresh_version >= [0, 2, 8]:
+            strategy = PyThreshThresholding(pythresh_thresholder=REGR(method="theil", random_state=42))
+            self._test_strategy(strategy, 0.72, [0, 0, 1, 0, 0, 0, 0, 0, 0])

--- a/timeeval/_version.py
+++ b/timeeval/_version.py
@@ -1,2 +1,2 @@
-__version__: str = "1.2.7"
+__version__: str = "1.2.8rc1"
 """Version of this TimeEval installation"""

--- a/timeeval/metrics/thresholding.py
+++ b/timeeval/metrics/thresholding.py
@@ -454,7 +454,7 @@ class PyThreshThresholding(ThresholdingStrategy):
 
 
 @contextlib.contextmanager
-def tmp_np_random_seed_pythresh(thresholder: 'BaseThresholder', random_state: Any) -> Generator[None, None, None]:
+def tmp_np_random_seed_pythresh(thresholder: 'BaseThresholder', random_state: Any) -> Generator[None, None, None]:   # type: ignore
     import pythresh.version
 
     pythresh_version = list(map(int, pythresh.version.__version__.split(".")))


### PR DESCRIPTION
With version 0.2.8 of [PyThresh](https://github.com/KulikDM/pythresh) the RNG seeding issue was resolved. The user should use the `random_state`-parameters of the pythresh thresholders from now on.

- deprecate `random_state` parameter of `timeeval.metrics.thresholding.PyThreshThresholding`
- if `random_state` is used after all: check version of pythresh and either seed the default RNG or override the `random_state` member of the pythresh thresholder. This allows backwards-compatibility and with older pythresh versions.