### PR TITLE
Fix custom datasets loading analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Evaluation Tool for Anomaly Detection Algorithms on Time Series.
 [![PyPI version](https://badge.fury.io/py/TimeEval.svg)](https://badge.fury.io/py/TimeEval)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![python version 3.7|3.8|3.9](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue)
+[![Downloads](https://pepy.tech/badge/timeeval)](https://pepy.tech/project/timeeval)
 
 </div>
 

--- a/requirements.ci
+++ b/requirements.ci
@@ -4,7 +4,7 @@ mypy==0.920
 twine
 freezegun
 # for the test of the PyThreshThresholding class:
-pythresh
+pythresh>=0.2.8
 
 # typings
 types-requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
-license_file = LICENSE
+license_files =
+    LICENSE
 
 [coverage:run]
 branch = False

--- a/tests/metrics/test_thresholding.py
+++ b/tests/metrics/test_thresholding.py
@@ -61,6 +61,27 @@ class TestThresholding(unittest.TestCase):
 
     @pytest.mark.skipif(_skip_pythresh_test == True, reason="PyThresh is not installed!")
     def test_pythresh_thresholding(self):
+        import pythresh.version
         from pythresh.thresholds.regr import REGR
-        strategy = PyThreshThresholding(pythresh_thresholder=REGR(method="theil"), random_state=42)
-        self._test_strategy(strategy, 0.44, [0, 0, 1, 1, 1, 1, 0, 0, 0])
+
+        with self.assertWarnsRegex(DeprecationWarning, "parameter is deprecated"):
+            strategy = PyThreshThresholding(pythresh_thresholder=REGR(method="theil"), random_state=42)
+
+        pythresh_version = list(map(int, pythresh.version.__version__.split(".")))
+        if pythresh_version >= [0, 2, 8]:
+            exp_threshold = 0.72
+            exp_res = [0, 0, 1, 0, 0, 0, 0, 0, 0]
+        else:
+            exp_threshold = 0.44
+            exp_res = [0, 0, 1, 1, 1, 1, 0, 0, 0]
+        self._test_strategy(strategy, exp_threshold, exp_res)
+
+    @pytest.mark.skipif(_skip_pythresh_test == True, reason="PyThresh is not installed!")
+    def test_pythresh_thresholding_new(self):
+        import pythresh.version
+        from pythresh.thresholds.regr import REGR
+
+        pythresh_version = list(map(int, pythresh.version.__version__.split(".")))
+        if pythresh_version >= [0, 2, 8]:
+            strategy = PyThreshThresholding(pythresh_thresholder=REGR(method="theil", random_state=42))
+            self._test_strategy(strategy, 0.72, [0, 0, 1, 0, 0, 0, 0, 0, 0])

--- a/timeeval/_version.py
+++ b/timeeval/_version.py
@@ -1,2 +1,2 @@
-__version__: str = "1.2.7"
+__version__: str = "1.2.8rc1"
 """Version of this TimeEval installation"""

--- a/timeeval/datasets/custom.py
+++ b/timeeval/datasets/custom.py
@@ -56,6 +56,7 @@ class CustomDatasets(CustomDatasetsBase):
             config = json.load(f)
         self.root_path: Path = dataset_config_path.parent
 
+        print("Analyzing custom datasets to validate them and extract their metadata.")
         store = {}
         for dataset in config:
             self._validate_dataset(dataset, config[dataset])
@@ -91,7 +92,8 @@ class CustomDatasets(CustomDatasetsBase):
         training_type = _training_type(train_path)
 
         # analyze test time series
-        dm = DatasetAnalyzer(dataset_id, is_train=False, dataset_path=test_path)
+        dm = DatasetAnalyzer(dataset_id, is_train=False, dataset_path=test_path, ignore_trend=True,
+                             ignore_stationarity=True)
 
         return CDEntry(test_path, train_path, Dataset(
             datasetId=dataset_id,

--- a/timeeval/metrics/thresholding.py
+++ b/timeeval/metrics/thresholding.py
@@ -1,5 +1,7 @@
 import abc
-from typing import Optional, Tuple, Any
+import contextlib
+import warnings
+from typing import Optional, Tuple, Any, Generator
 
 import numpy as np
 
@@ -351,7 +353,7 @@ class PyThreshThresholding(ThresholdingStrategy):
 
       .. code-block:: bash
 
-        pip install pythresh
+        pip install pythresh>=0.2.8
 
       Please note the additional package requirements for some available thresholders of PyThresh.
 
@@ -365,6 +367,11 @@ class PyThreshThresholding(ThresholdingStrategy):
         left at its default value for most thresholders that don't use random numbers or provide their own way of
         seeding. Please consult the `PyThresh Documentation <https://pythresh.readthedocs.io/en/latest/index.html>`_
         for details about the individual thresholders.
+
+        .. deprecated:: 1.2.8
+            Since pythresh version 0.2.8, thresholders provide a way to set their RNG state correctly. So the parameter
+            ``random_state`` is not needed anymore. Please use the pythresh thresholder's parameter to seed it. This
+            function's parameter is kept for compatibility with pythresh<0.2.8.
 
     Examples
     --------
@@ -387,6 +394,10 @@ class PyThreshThresholding(ThresholdingStrategy):
         self._thresholder = pythresh_thresholder
         self._predictions: Optional[np.ndarray] = None
         self._random_state: Any = random_state
+        if random_state is not None:
+            warnings.warn("'random_state' parameter is deprecated. Use pythresh thresholder's parameter instead.",
+                          DeprecationWarning,
+                          stacklevel=2)
 
     @staticmethod
     def _make_finite(y_score: np.ndarray) -> np.ndarray:
@@ -421,16 +432,12 @@ class PyThreshThresholding(ThresholdingStrategy):
         """
         y_score = self._make_finite(y_score)
 
-        # seed legacy np.random for reproducibility
-        old_state = np.random.get_state()
-        np.random.seed(self._random_state)
+        # fix seeding (depending on pythresh version) and if random_state is supplied
+        with tmp_np_random_seed_pythresh(self._thresholder, self._random_state):
+            # call PyThresh
+            self._predictions = self._thresholder.eval(y_score)
+            threshold: float = self._thresholder.thresh_
 
-        # call PyThresh
-        self._predictions = self._thresholder.eval(y_score)
-        threshold: float = self._thresholder.thresh_
-
-        # reset np.random state
-        np.random.set_state(old_state)
         return threshold
 
     def transform(self, y_score: np.ndarray) -> np.ndarray:
@@ -444,3 +451,23 @@ class PyThreshThresholding(ThresholdingStrategy):
 
     def __repr__(self) -> str:
         return f"PyThreshThresholding(pythresh_thresholding={repr(self._thresholder)})"
+
+
+@contextlib.contextmanager
+def tmp_np_random_seed_pythresh(thresholder: 'BaseThresholder', random_state: Any) -> Generator[None, None, None]:   # type: ignore
+    import pythresh.version
+
+    pythresh_version = list(map(int, pythresh.version.__version__.split(".")))
+    if pythresh_version < [0, 2, 8]:
+        # seed legacy np.random for reproducibility
+        old_state = np.random.get_state()
+        np.random.seed(random_state)
+        try:
+            yield
+        finally:
+            # reset np.random state
+            np.random.set_state(old_state)
+    else:
+        if random_state is not None and hasattr(thresholder, "random_state"):
+            setattr(thresholder, "random_state", random_state)
+        yield


### PR DESCRIPTION
Loading custom datasets with TimeEval will lead to long waiting times and very high memory consumption because of the early metadata collection. We only need the basic statistics about the datasets that early, though. This PR excludes the trend and stationarity analysis from the loading process (reducing runtime and memory usage).

**Depends on #49 to be merged first!**