### PR TITLE
Add check for no valid experiments in TimeEval configuration

### DIFF
--- a/tests/test_timeeval_exceptions.py
+++ b/tests/test_timeeval_exceptions.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import tempfile
 import unittest
 from pathlib import Path
@@ -7,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from tests.fixtures.algorithms import ErroneousAlgorithm
-from timeeval import TimeEval, Algorithm, Datasets, DatasetManager, Status, ResourceConstraints
+from timeeval import TimeEval, Algorithm, Datasets, DatasetManager, Status, ResourceConstraints, TrainingType
 from timeeval.adapters import FunctionAdapter
 
 
@@ -81,3 +82,10 @@ class TestTimeEvalExceptions(unittest.TestCase):
 
         self.assertEqual(r[r.algorithm == "exception"].iloc[0].status, Status.ERROR)
         self.assertIn(ERROR_MESSAGE, r[r.algorithm == "exception"].iloc[0].error_message)
+
+    def test_no_experiments(self):
+        algo = deepcopy(self.identity_algorithm)
+        algo.training_type = TrainingType.SUPERVISED
+        with self.assertRaises(AssertionError) as ex:
+            TimeEval(self.datasets, [("test", "dataset-int")], [algo])
+        self.assertRegex(str(ex.exception), "[Nn]o [Vv]alid [Ee]xperiments")

--- a/timeeval/_core/experiments.py
+++ b/timeeval/_core/experiments.py
@@ -227,8 +227,8 @@ class Experiments:
                         # create parameter hash before executing heuristics
                         # (they replace the parameter values, but we want to be able to group by original configuration)
                         params_id = algorithm_config.uid()
-                        params = inject_heuristic_values(algorithm_config, algorithm, dataset, test_path)
                         if self._should_be_run(algorithm, dataset, params_id):
+                            params = inject_heuristic_values(algorithm_config, algorithm, dataset, test_path)
                             for repetition in range(1, self.repetitions + 1):
                                 yield Experiment(
                                     algorithm=algorithm,

--- a/timeeval/timeeval.py
+++ b/timeeval/timeeval.py
@@ -300,6 +300,11 @@ class TimeEval:
                                 force_dimensionality_match=force_dimensionality_match,
                                 metrics=self.metrics,
                                 experiment_combinations_file=experiment_combinations_file)
+        assert len(self.exps) != 0, "No valid experiments configured! Please check that the input dimensionality and " \
+                                    "training type of algorithms and datasets match. You can use the parameters "\
+                                    "``skip_invalid_combinations``, ``force_training_type_match``, "\
+                                    "``force_dimensionality_match``, and ``experiment_combinations_file`` to control " \
+                                    "which algorithm runs on which dataset."
 
         self.remote_config: RemoteConfiguration = remote_config or RemoteConfiguration()
         self.remote_config.update_logging_path(self.results_path)
@@ -547,10 +552,10 @@ class TimeEval:
         )
 
     def _prepare(self) -> None:
-        n = len(self.exps)
-        self.log.debug(f"Running {n} algorithm prepare steps")
+        self.log.debug(f"Running {len(self.exps.algorithms)} algorithm prepare steps")
         for algorithm in self.exps.algorithms:
             algorithm.prepare()
+        n = len(self.exps)
         self.log.debug(f"Creating {n} result directories")
         for exp in self.exps:
             exp.results_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Check for valid experiments in the TimeEval configuration. If there are none, then print a proper error message.

This should prevent errors with the following (cryptic) message or empty results:

```
Traceback (most recent call last):
  File "[...]", line 170, in <module>
    main()
  File "[...]", line 165, in main
    timeeval.run()
  File "[...]/timeeval/timeeval.py", line 595, in run
    self._resolve_future_results()
  File "[...]/timeeval/timeeval.py", line 396, in _resolve_future_results
    self.results[keys] = self.results["future_result"].apply(get_future_result).tolist()
  File "[...]/site-packages/pandas/core/frame.py", line 3600, in __setitem__
    self._setitem_array(key, value)
  File "[...]/site-packages/pandas/core/frame.py", line 3656, in _setitem_array
    self._iset_not_inplace(key, value)
  File "[...]/site-packages/pandas/core/frame.py", line 3675, in _iset_not_inplace
    raise ValueError("Columns must be same length as key")
ValueError: Columns must be same length as key
```

---
Thanks to @B-Seif for reporting this in #88